### PR TITLE
feat(platform): filter plans by platform tabs + enable tab ordering

### DIFF
--- a/assets/admin/css/admin.css
+++ b/assets/admin/css/admin.css
@@ -266,3 +266,49 @@
 .pwpl-card-device__height input {
   width: 100%;
 }
+
+.pwpl-platform-order {
+  margin-top: 12px;
+  border: 1px solid #dbe4f0;
+  border-radius: 6px;
+  padding: 12px;
+  background: #ffffff;
+  display: grid;
+  gap: 10px;
+}
+
+.pwpl-platform-order__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.pwpl-platform-order__default {
+  font-size: 13px;
+  color: #475569;
+}
+
+.pwpl-platform-order__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 6px;
+}
+
+.pwpl-platform-order__list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 10px;
+  border: 1px solid #e5ecf6;
+  border-radius: 4px;
+  background: #f8fbff;
+}
+
+.pwpl-order-actions {
+  display: flex;
+  gap: 6px;
+}

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -456,6 +456,10 @@
   color: var(--pwpl-muted, #475569);
 }
 
+.pwpl-hidden {
+  display: none !important;
+}
+
 @media (max-width: 767px) {
   .pwpl-table {
     padding: 20px;


### PR DESCRIPTION
### Summary

This update introduces platform-based filtering for plan cards and adds admin-controlled ordering for Platform tabs.

- Only plans matching the selected platform are shown (Windows/Linux).
- Default active platform is determined by admin ordering.
- Platform tabs can now be reordered in the Table editor.
- Price/CTA/billing updates remain intact when switching tabs.

### Files Updated

- includes/class-pwpl-shortcode.php
- includes/class-pwpl-admin-meta.php
- assets/js/frontend.js
- assets/css/frontend.css
- assets/admin/js/admin.js
- assets/admin/css/admin.css

### Testing

1. In wp-admin → Table → enable Platform dimension with Windows + Linux.
2. Reorder Windows/Linux and save.
3. On frontend, confirm initial active platform matches saved order.
4. Switch between platforms → only matching plans appear.
5. Disable Platform → all plans render (no filtering).