### PR TITLE
fix(dimensions): graceful fallback when a Platform has no valid Period/Location

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -460,6 +460,10 @@
   display: none !important;
 }
 
+.pwpl-unavailable {
+  opacity: 0.6;
+}
+
 @media (max-width: 767px) {
   .pwpl-table {
     padding: 20px;

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -168,6 +168,11 @@
         const allowedPeriods = platform && periodsByPlatform[platform] ? periodsByPlatform[platform] : [];
         const tabs = nav.querySelectorAll('.pwpl-tab');
         let activeSlug = table.dataset.activePeriod || '';
+        if (!allowedPeriods.length && platform) {
+            console.warn('[PWPL] No period options available for platform:', platform);
+            tabs.forEach(function(tab){ tab.classList.remove('pwpl-hidden'); });
+            return activeSlug;
+        }
         tabs.forEach(function(tab){
             const slug = tab.dataset.value || '';
             const allowed = !allowedPeriods.length || allowedPeriods.indexOf(slug) !== -1;
@@ -214,6 +219,11 @@
         const allowedLocations = platform && locationsByPlatform[platform] ? locationsByPlatform[platform] : [];
         const tabs = nav.querySelectorAll('.pwpl-tab');
         let activeSlug = table.dataset.activeLocation || '';
+        if (!allowedLocations.length && platform) {
+            console.warn('[PWPL] No location options available for platform:', platform);
+            tabs.forEach(function(tab){ tab.classList.remove('pwpl-hidden'); });
+            return activeSlug;
+        }
         tabs.forEach(function(tab){
             const slug = tab.dataset.value || '';
             const allowed = !allowedLocations.length || allowedLocations.indexOf(slug) !== -1;

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -626,8 +626,14 @@
     document.querySelectorAll('.pwpl-table').forEach(function(table){
         ensurePlatformDefault(table);
         if (table.dataset.activePlatform) {
-            filterPeriodsByPlatform(table, table.dataset.activePlatform);
-            filterLocationsByPlatform(table, table.dataset.activePlatform);
+            const normalizedPeriod = filterPeriodsByPlatform(table, table.dataset.activePlatform);
+            const normalizedLocation = filterLocationsByPlatform(table, table.dataset.activePlatform);
+            if (normalizedPeriod) {
+                table.dataset.activePeriod = normalizedPeriod;
+            }
+            if (normalizedLocation) {
+                table.dataset.activeLocation = normalizedLocation;
+            }
         }
         enhanceRail(table);
         updateTable(table);

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -203,6 +203,39 @@
         }
     }
 
+    // Mirror period filtering for location tabs.
+    function filterLocationsByPlatform(table, platform) {
+        const nav = table.querySelector('.pwpl-dimension-nav[data-dimension="location"]');
+        if (!nav) {
+            return '';
+        }
+        const availability = table.dataset.availability ? safeParseJSON(table.dataset.availability, {}) : {};
+        const locationsByPlatform = availability.locationsByPlatform || {};
+        const allowedLocations = platform && locationsByPlatform[platform] ? locationsByPlatform[platform] : [];
+        const tabs = nav.querySelectorAll('.pwpl-tab');
+        let activeSlug = table.dataset.activeLocation || '';
+        tabs.forEach(function(tab){
+            const slug = tab.dataset.value || '';
+            const allowed = !allowedLocations.length || allowedLocations.indexOf(slug) !== -1;
+            tab.classList.toggle('pwpl-hidden', !allowed);
+            if (!allowed && tab.classList.contains('is-active')) {
+                tab.classList.remove('is-active');
+                tab.setAttribute('aria-pressed', 'false');
+                activeSlug = '';
+            }
+        });
+
+        if (!activeSlug) {
+            const firstVisible = nav.querySelector('.pwpl-tab:not(.pwpl-hidden)');
+            if (firstVisible) {
+                activeSlug = firstVisible.dataset.value || '';
+                setActive(table, 'location', activeSlug, firstVisible);
+            }
+        }
+
+        return activeSlug;
+    }
+
     function ensurePlatformDefault(table) {
         const allowed = parseAllowedPlatforms(table);
         if (!allowed.length) {
@@ -565,6 +598,8 @@
         }
         if (dimension === 'platform') {
             filterPlansByPlatform(table, value);
+            filterPeriodsByPlatform(table, value);
+            filterLocationsByPlatform(table, value);
         }
         updateTable(table);
     }
@@ -592,6 +627,7 @@
         ensurePlatformDefault(table);
         if (table.dataset.activePlatform) {
             filterPeriodsByPlatform(table, table.dataset.activePlatform);
+            filterLocationsByPlatform(table, table.dataset.activePlatform);
         }
         enhanceRail(table);
         updateTable(table);


### PR DESCRIPTION
- When a Platform has no valid Period or Location, the UI now falls back to showing all tabs rather than leaving the set empty.
- Adds console warnings for dev visibility.
- Keeps current active tab stable; no pricing/CTA breakage.

Files:
- assets/js/frontend.js
- assets/css/frontend.css

Test:
- Configure a Platform with no valid Periods/Locations and switch to it: tabs remain visible + console.warn emitted.
- Normal cases still filter correctly.